### PR TITLE
Link to CoinUtils.lib only; remove direct MKL linkage in Osi build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ else
 fi
 
 if [[ "${target_platform}" == win-* ]]; then
-  COINUTILS_LIB=( --with-coinutils-lib='${LIBRARY_PREFIX}/lib/mkl_rt.lib ${LIBRARY_PREFIX}/lib/libCoinUtils.lib' )
+  COINUTILS_LIB=( --with-coinutils-lib='${LIBRARY_PREFIX}/lib/libCoinUtils.lib' )
   COINUTILS_INC=( --with-coinutils-incdir='${LIBRARY_PREFIX_COIN}' )
   EXTRA_FLAGS=( --enable-msvc=MD ) 
 else

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,12 +33,6 @@ requirements:
     - m2-base  # [win]
   host:
     - coin-or-utils
-    - blas-devel
-    - libblas  # [unix]
-    - libcblas  # [unix]
-    - liblapack  # [unix]
-    - liblapacke  # [unix]
-    - mkl  # [win]
     - zlib
     - bzip2
   run_constrained:


### PR DESCRIPTION
CoinUtils is already linked against MKL during its own build process.
Osi itself does not make direct BLAS/LAPACK or MKL calls.
Therefore, explicitly passing MKL libraries during Osi's build is unnecessary and may lead to unresolved symbols or linking conflicts.